### PR TITLE
카테고리 집합, 카테고리의 상품 조회에 대한 라우팅 설정

### DIFF
--- a/routes/api/category.js
+++ b/routes/api/category.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const categoryInfo = require('../../services/eleven/categoryInfo');
+const getCatSet = require('../../services/getCatSet');
+
+router.get('/', async (req, res) => {
+  res.json(await getCatSet());
+});
+
+router.get('/:code', async (req, res) => {
+  res.json(
+    await categoryInfo({
+      pg: req.query.pg,
+      srt: req.query.srt,
+      code: req.params.code,
+    }),
+  );
+});
+
+module.exports = router;

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -1,24 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const productSearch = require('../../services/eleven/productSearch');
-const categoryInfo = require('../../services/eleven/categoryInfo');
-const getCatSet = require('../../services/getCatSet');
-
+const category = require('./category');
 
 /**
  * API 요청에 대한 라우팅 정의
  */
-router.use('/product', async (req, res)=>{
-    res.send(await productSearch(req.query));
-});
 
-
-router.use('/category', async (req, res)=>{
-    res.send(await categoryInfo(req.query));
-});
-
-router.use('/set', async (req, res)=>{
-    res.send(await getCatSet());
-});
+router.use('/category', category);
 
 module.exports = router;

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -4,14 +4,14 @@ const iconv = require('iconv-lite');
 const apiKey = require('../../config/apiKey.json');
 
 /**
- * cat은 카테고리코드이다.
+ * code 카테고리코드이다.
  * sortCd(CP:인기, A: 판매순, G:평가높은순, I:후기/리뷰순, L:낮은 가격순, H:높은 가격순, N: 최근 등록순),
- * @param {cat, pg, srt} query 
+ * @param {code, pg, srt} query 
  * @returns 완성된 요청 url
  */
 const getApiRequest = (query) => {
   let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=CategoryInfo&pageSize=12&option=Products`;
-  if (query.cat) url += `&categoryCode=${query.cat}`;
+  if (query.code) url += `&categoryCode=${query.code}`;
   if (query.pg) url += `&pageNum=${query.pg}`;
   if (query.srt) url += `&sortCd=${query.srt}`;
   return url;


### PR DESCRIPTION
- /category 는 전체 카테고리 목록 반환
- /category/:code는 카테고리에 속한 상품들 반환
- category/:code를 통해 해당 카테고리에 속한 상품들을 반환
- 추가적으로 통일성을 위해 categoryInfo의 getApiRequest 의 cat 인자를 code로 이름 바꿈.
~2커밋 전부 한번에 커밋했어야 했으나 실수로 category.js 파일 바뜨려서 한번 더 커밋함.~