### PR TITLE
제품 상세 정보를 요청하는 API 생성

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const category = require('./category');
+const product = require('./product');
 
 /**
  * API 요청에 대한 라우팅 정의
  */
 
 router.use('/category', category);
+router.use('/product', product);
 
 module.exports = router;

--- a/routes/api/product.js
+++ b/routes/api/product.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const productInfo = require('../../services/eleven/productInfo');
+
+router.get('/:code', async (req, res) => {
+  res.json(
+    await productInfo({
+      opt: req.query.opt,
+      code: req.params.code,
+    }),
+  );
+});
+
+module.exports = router;

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -6,7 +6,7 @@ const apiKey = require('../../config/apiKey.json');
 /**
  * code 카테고리코드이다.
  * sortCd(CP:인기, A: 판매순, G:평가높은순, I:후기/리뷰순, L:낮은 가격순, H:높은 가격순, N: 최근 등록순),
- * @param {code, pg, srt} query 
+ * @param {code, pg, srt} query
  * @returns 완성된 요청 url
  */
 const getApiRequest = (query) => {
@@ -22,28 +22,33 @@ module.exports = async (query) => {
     method: 'get',
     url: getApiRequest(query),
     responseType: 'arraybuffer', //arraybuffer를 해야 size가 정의되고 iconv.decode를 사용가능.
-  }).then((response) =>
-    JSON.parse(
-      convert.xml2json(iconv.decode(response.data, 'euc-kr'), {
-        compact: true,
-        ignoreAttributes: true,
-        ignoreDeclaration: true,
-      }),
-    ),
-  ).then(result => ({
-    products: {
-      count: result.CategoryResponse.Products.TotalCount._text,
-      items: result.CategoryResponse.Products.Product?(result.CategoryResponse.Products.Product.map((prod) => ({
-        code: prod.ProductCode._text,
-        name: prod.ProductName._cdata,
-        price: prod.ProductPrice._text,
-        image: prod.ProductImage300._cdata
-      }))): result.CategoryResponse.Products.Product
-    },
-    category: {
-      name : result.CategoryResponse.Category.CategoryName._cdata,
-      code: result.CategoryResponse.Category.CategoryCode._text,
-    }
-  })).catch(error => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
+  })
+    .then((response) =>
+      JSON.parse(
+        convert.xml2json(iconv.decode(response.data, 'euc-kr'), {
+          compact: true,
+          ignoreAttributes: true,
+          ignoreDeclaration: true,
+        }),
+      ),
+    )
+    .then((result) => ({
+      products: {
+        count: result.CategoryResponse.Products.TotalCount._text,
+        items: result.CategoryResponse.Products.Product
+          ? result.CategoryResponse.Products.Product.map((prod) => ({
+              code: prod.ProductCode._text,
+              name: prod.ProductName._cdata,
+              price: prod.ProductPrice._text,
+              image: prod.ProductImage300._cdata,
+            }))
+          : result.CategoryResponse.Products.Product,
+      },
+      category: {
+        name: result.CategoryResponse.Category.CategoryName._cdata,
+        code: result.CategoryResponse.Category.CategoryCode._text,
+      },
+    }))
+    .catch((error) => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
   return result;
 };

--- a/services/eleven/productInfo.js
+++ b/services/eleven/productInfo.js
@@ -1,0 +1,51 @@
+const axios = require('axios');
+const convert = require('xml-js');
+const iconv = require('iconv-lite');
+const apiKey = require('../../config/apiKey.json');
+
+/**
+ * code 상품코드이다.
+ * option
+ * - QAs: 상품Q&A 조회 결과 요청
+ * - PostScripts: 사용후기 조회 결과 요청
+ * - PdOption: 상품 옵션 정보 조회 결과 요청
+ * @param {code, opt} query
+ * @returns 완성된 요청 url
+ */
+const getApiRequest = (query) => {
+  let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=ProductInfo`;
+  if (query.code) url += `&productCode=${query.code}`;
+  if (query.opt) url += `&option=${query.opt}`;
+  return url;
+};
+
+module.exports = async (query) => {
+  let result = await axios({
+    method: 'get',
+    url: getApiRequest(query),
+    responseType: 'arraybuffer', //arraybuffer를 해야 size가 정의되고 iconv.decode를 사용가능.
+  })
+    .then((response) =>
+      JSON.parse(
+        convert.xml2json(iconv.decode(response.data, 'euc-kr'), {
+          compact: true,
+          ignoreAttributes: true,
+          ignoreDeclaration: true,
+        }),
+      ),
+    )
+    .then((result) => ({
+      code: result.ProductInfoResponse.Product.ProductCode._text,
+      name: result.ProductInfoResponse.Product.ProductName._cdata,
+      price: {
+        origin: result.ProductInfoResponse.Product.ProductPrice.Price._text,
+        lowest:
+          result.ProductInfoResponse.Product.ProductPrice.LowestPrice._text,
+      },
+      image: result.ProductInfoResponse.Product.BasicImage._cdata,
+      shipFee: result.ProductInfoResponse.Product.ShipFee._text,
+      satisfaction: result.ProductInfoResponse.Product.SellSatisfaction._text,
+    }))
+    .catch((error) => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
+  return result;
+};

--- a/services/eleven/productInfo.js
+++ b/services/eleven/productInfo.js
@@ -6,14 +6,14 @@ const apiKey = require('../../config/apiKey.json');
 /**
  * code 상품코드이다.
  * option
- * - QAs: 상품Q&A 조회 결과 요청
- * - PostScripts: 사용후기 조회 결과 요청
- * - PdOption: 상품 옵션 정보 조회 결과 요청
- * @param {code, opt} query
+ * - QAs: 상품Q&A 조회 결과 요청, 안되는걸로 확인
+ * - PostScripts: 사용후기 조회 결과 요청, 안되는걸로 확인.
+ * - PdOption: 상품 옵션 정보 조회 결과 요청,
+ * @param {code} query
  * @returns 완성된 요청 url
  */
 const getApiRequest = (query) => {
-  let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=ProductInfo`;
+  let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=ProductInfo&option=PdOption`;
   if (query.code) url += `&productCode=${query.code}`;
   if (query.opt) url += `&option=${query.opt}`;
   return url;
@@ -45,6 +45,21 @@ module.exports = async (query) => {
       image: result.ProductInfoResponse.Product.BasicImage._cdata,
       shipFee: result.ProductInfoResponse.Product.ShipFee._text,
       satisfaction: result.ProductInfoResponse.Product.SellSatisfaction._text,
+      exist: result.ProductInfoResponse.ProductOption.status._text,
+      optionList:
+        result.ProductInfoResponse.ProductOption.OptionList &&
+        Object.values(result.ProductInfoResponse.ProductOption.OptionList).map(
+          (option) => ({
+            order: option.Order._text,
+            name: option.TitleName._text,
+            mandatory: option.MandatoryYN._text,
+            values: option.ValueList.Value.map((value) => ({
+              order: value.Order._text,
+              name: value.ValueName._text,
+              price: value.Price._text,
+            })),
+          }),
+        ),
     }))
     .catch((error) => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
   return result;

--- a/services/getCatSet.js
+++ b/services/getCatSet.js
@@ -10,12 +10,12 @@ module.exports = async () => {
     return null;
   }
   let selected = [];
-  for(let cat of result.categories){
-    if(cat.name.includes("의류")||cat.name.includes("패션")){
-      selected.push(({
-        name : cat.name,
-        code : cat.url.slice(cat.url.indexOf("dispCtgrNo=")+11)//code가 despCtgtNo=뒤에옴
-      }));
+  for (let cat of result.categories) {
+    if (cat.name.includes('의류') || cat.name.includes('패션')) {
+      selected.push({
+        name: cat.name,
+        code: cat.url.slice(cat.url.indexOf('dispCtgrNo=') + 11), //code가 despCtgtNo=뒤에옴
+      });
     }
   }
   return selected;


### PR DESCRIPTION
- 제품에 대한 요청을 라우팅하는 product.js 생성
- OpenAPI에 제품 상세 정보를 대신 요청하는 productInfo.js 생성
- 서버에서 Open api에 요청보낼때 PdOption 무조건 포함
- 포함시켜야 상품 품절 밑 옵션(사이즈 등) 정보를 알 수가 있음.
- option에 제공되는 PostScripts는 Open API 기능 제공이 중단된 상태고 QAs는 QNA가 있는 게시글을 아직 못봐서 되는지는 모르겠지만 이정도로 있는 게시글을 찾기 힘들정도면 빼는게 나음