### PR TITLE
Category API 패치

### DIFF
--- a/react-front-app/src/pages/HomePage.js
+++ b/react-front-app/src/pages/HomePage.js
@@ -45,7 +45,7 @@ const Home = () => {
         });
       })
       .catch((e) => console.log(e));
-  }, []);
+  }, [setBannerImgs]);
 
   return (
     <>

--- a/routes/api/category.js
+++ b/routes/api/category.js
@@ -4,7 +4,7 @@ const categoryInfo = require('../../services/eleven/categoryInfo');
 const getCatSet = require('../../services/getCatSet');
 
 router.get('/', async (req, res) => {
-  res.json(await getCatSet());
+  res.json(getCatSet());
 });
 
 router.get('/:code', async (req, res) => {

--- a/routes/api/category.js
+++ b/routes/api/category.js
@@ -10,8 +10,7 @@ router.get('/', async (req, res) => {
 router.get('/:code', async (req, res) => {
   res.json(
     await categoryInfo({
-      pg: req.query.pg,
-      srt: req.query.srt,
+      ...req.query,
       code: req.params.code,
     }),
   );

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -35,38 +35,35 @@ module.exports = async (query) => {
         }),
       ),
     )
-    .then((result) => {
-      console.log(result);
-      return {
-        products: {
-          count: result.CategoryResponse.Products.TotalCount._text,
-          items:
-            result.CategoryResponse.Products.Product &&
-            (result.CategoryResponse.Products.Product.map
-              ? result.CategoryResponse.Products.Product.map((prod) => ({
-                  code: prod.ProductCode._text,
-                  name: prod.ProductName._cdata,
-                  price: prod.ProductPrice._text,
-                  image: prod.ProductImage300._cdata,
-                }))
-              : {
-                  code: result.CategoryResponse.Products.Product.ProductCode
-                    ._text,
-                  name: result.CategoryResponse.Products.Product.ProductName
+    .then((result) => ({
+      products: {
+        count: result.CategoryResponse.Products.TotalCount._text,
+        items:
+          result.CategoryResponse.Products.Product &&
+          (result.CategoryResponse.Products.Product.map
+            ? result.CategoryResponse.Products.Product.map((prod) => ({
+                code: prod.ProductCode._text,
+                name: prod.ProductName._cdata,
+                price: prod.ProductPrice._text,
+                image: prod.ProductImage300._cdata,
+              }))
+            : {
+                code: result.CategoryResponse.Products.Product.ProductCode
+                  ._text,
+                name: result.CategoryResponse.Products.Product.ProductName
+                  ._cdata,
+                price:
+                  result.CategoryResponse.Products.Product.ProductPrice._text,
+                image:
+                  result.CategoryResponse.Products.Product.ProductImage300
                     ._cdata,
-                  price:
-                    result.CategoryResponse.Products.Product.ProductPrice._text,
-                  image:
-                    result.CategoryResponse.Products.Product.ProductImage300
-                      ._cdata,
-                }),
-        },
-        category: {
-          name: result.CategoryResponse.Category.CategoryName._cdata,
-          code: result.CategoryResponse.Category.CategoryCode._text,
-        },
-      };
-    })
+              }),
+      },
+      category: {
+        name: result.CategoryResponse.Category.CategoryName._cdata,
+        code: result.CategoryResponse.Category.CategoryCode._text,
+      },
+    }))
     .catch((error) => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
   return result;
 };

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -15,8 +15,8 @@ const getApiRequest = (query) => {
   if (query.pg) url += `&pageNum=${query.pg}`;
   if (query.srt) url += `&sortCd=${query.srt}`;
   let pageSize = 12;
-  if(query.size&&query.size>0) pageSize = query.size;
-  url+=`&pageSize=${pageSize}`;
+  if (query.size && query.size > 0) pageSize = query.size;
+  url += `&pageSize=${pageSize}`;
   return url;
 };
 
@@ -35,23 +35,38 @@ module.exports = async (query) => {
         }),
       ),
     )
-    .then((result) => ({
-      products: {
-        count: result.CategoryResponse.Products.TotalCount._text,
-        items: result.CategoryResponse.Products.Product
-          ? result.CategoryResponse.Products.Product.map((prod) => ({
-              code: prod.ProductCode._text,
-              name: prod.ProductName._cdata,
-              price: prod.ProductPrice._text,
-              image: prod.ProductImage300._cdata,
-            }))
-          : result.CategoryResponse.Products.Product,
-      },
-      category: {
-        name: result.CategoryResponse.Category.CategoryName._cdata,
-        code: result.CategoryResponse.Category.CategoryCode._text,
-      },
-    }))
+    .then((result) => {
+      console.log(result);
+      return {
+        products: {
+          count: result.CategoryResponse.Products.TotalCount._text,
+          items:
+            result.CategoryResponse.Products.Product &&
+            (result.CategoryResponse.Products.Product.map
+              ? result.CategoryResponse.Products.Product.map((prod) => ({
+                  code: prod.ProductCode._text,
+                  name: prod.ProductName._cdata,
+                  price: prod.ProductPrice._text,
+                  image: prod.ProductImage300._cdata,
+                }))
+              : {
+                  code: result.CategoryResponse.Products.Product.ProductCode
+                    ._text,
+                  name: result.CategoryResponse.Products.Product.ProductName
+                    ._cdata,
+                  price:
+                    result.CategoryResponse.Products.Product.ProductPrice._text,
+                  image:
+                    result.CategoryResponse.Products.Product.ProductImage300
+                      ._cdata,
+                }),
+        },
+        category: {
+          name: result.CategoryResponse.Category.CategoryName._cdata,
+          code: result.CategoryResponse.Category.CategoryCode._text,
+        },
+      };
+    })
     .catch((error) => console.log(error.message)); //response의 인코딩은 euc-kr이지만 axios에서 디코딩이 지원 안되기 때문에 iconv 사용
   return result;
 };

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -6,14 +6,17 @@ const apiKey = require('../../config/apiKey.json');
 /**
  * code 카테고리코드이다.
  * sortCd(CP:인기, A: 판매순, G:평가높은순, I:후기/리뷰순, L:낮은 가격순, H:높은 가격순, N: 최근 등록순),
- * @param {code, pg, srt} query
+ * @param {code, pg, srt, size} query
  * @returns 완성된 요청 url
  */
 const getApiRequest = (query) => {
-  let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=CategoryInfo&pageSize=12&option=Products`;
+  let url = `http://openapi.11st.co.kr/openapi/OpenApiService.tmall?key=${apiKey.key}&apiCode=CategoryInfo&option=Products`;
   if (query.code) url += `&categoryCode=${query.code}`;
   if (query.pg) url += `&pageNum=${query.pg}`;
   if (query.srt) url += `&sortCd=${query.srt}`;
+  let pageSize = 12;
+  if(query.size&&query.size>0) pageSize = query.size;
+  url+=`&pageSize=${pageSize}`;
   return url;
 };
 

--- a/services/getCatSet.js
+++ b/services/getCatSet.js
@@ -1,8 +1,9 @@
-const product = require('./eleven/productSearch');
+//const product = require('./eleven/productSearch');
 
 /**
  * 전체 의류 카테고리 집합을 반환
  */
+/*
 module.exports = async () => {
   let result = await product({});
   if (!result) {
@@ -19,4 +20,89 @@ module.exports = async () => {
     }
   }
   return selected;
+};
+*/
+//검색에 안나오는 카테고리가 태반이고, Child 카테고리가 안뜨므로 직접 사이트 카테고리를 따옴
+const categories = [
+  {
+    name: '브랜드 남성의류',
+    code: 1001296,
+    child: [
+      { name: '셔츠/남방', code: 1001718, top: true },
+      { name: '티셔츠', code: 1001719, top: true },
+      { name: '바지/팬츠', code: 1001721, top: false },
+      { name: '조끼/베스트', code: 1001717, top: true },
+      { name: '니트/스웨터', code: 1001716, top: true },
+      { name: '카디건', code: 1001715, top: true },
+      { name: '재킷', code: 1001713, top: true },
+      { name: '코트', code: 1001712, top: true },
+      { name: '점퍼', code: 1001714, top: true },
+    ],
+  },
+  {
+    name: '브랜드 여성의류',
+    code: 1001295,
+    child: [
+      { name: '원피스', code: 1001768, top: true },
+      { name: '블라우스', code: 1001764, top: true },
+      { name: '티셔츠', code: 1001766, top: true },
+      { name: '셔츠', code: 1001765, top: true },
+      { name: '니트/스웨터', code: 1001762, top: true },
+      { name: '카디건', code: 1001761, top: true },
+      { name: '베스트/조끼', code: 1001763, top: true },
+      { name: '바지/팬츠', code: 1001770, top: false },
+      { name: '스커트/치마', code: 1001769, top: true },
+      { name: '청바지', code: 1001771, top: false },
+      { name: '레깅스', code: 1001767, top: false },
+      { name: '점퍼', code: 1001760, top: true },
+      { name: '재킷', code: 1001759, top: true },
+      { name: '코트', code: 1001758, top: true },
+      {
+        name: '트레이닝복',
+        code: 1001773,
+        child: [
+          {
+            name: '트레이닝 상의',
+            code: 1010261,
+            top: true,
+          },
+          {
+            name: '트리이닝 하의',
+            code: 1010263,
+            top: false,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const classifyTop = (category, top, pants) => {
+  let [tempTop, tempPants] = [[], []];
+  if (category.child) {
+    for (let subCat of category.child) {
+      classifyTop(subCat, tempTop, tempPants);
+    }
+    top.push({name:category.name,child:tempTop});
+    pants.push({name:category.name,child:tempPants});
+  } else {
+    if (category.top) {
+      top.push(category);
+    } else {
+      pants.push(category);
+    }
+  }
+};
+
+module.exports = () => {
+  let top = [];
+  let pants = [];
+  for (let category of categories) {
+    classifyTop(category, top, pants);
+  }
+  return [
+    ...categories,
+    { name: 'top', child: top },
+    { name: 'pants', child: pants },
+  ];
 };


### PR DESCRIPTION
- Category API가 Open API로부터 응답받은 상품 리스트의 크기가 1일때  출력하지 못하는 문제 해결
- Open API 응답 XML은 JSON으로 파싱될 때 어떤 요소의 하위요소가 단일 요소일 때는 리스트가
  아닌 오브젝트로 파싱된다 따라서 해당 경우를 따로 분리해줬다.
- 현재 Open API의 서브 카테고리 기능이 작동안됨
- 또한 Open API의 전체 카테고리 조회에 서브 카테고리 등을 포함한 최신 카테고리들이 조회가 안됨.
- 따라서 11번가 사이트에서 우리에게 필요한 카테고리와 코드들을 따옴.

**이제 서브 카테고리를 API를 통해 받을 수 있고 각 카테고리의 상의, 하의 여부를 알 수 있게 해두었다**