### PR TITLE
Category API, 메인 배너 패치

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,6 @@
 
 # HomePage.js 파일 소유
 HomePage.js @rkdgusrn1212
+
+# page/Banner.js 파일 소유
+page/Banner.js @rkdgusrn1212

--- a/react-front-app/.gitignore
+++ b/react-front-app/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# yarn npm lock 파일 제외
+yarn.lock
+package-lock.json

--- a/react-front-app/package.json
+++ b/react-front-app/package.json
@@ -13,6 +13,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.0",
     "react-dom": "^18.2.0",
+    "react-lazy-load-image-component": "^1.5.6",
     "react-router-dom": "^6.4.5",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.0"

--- a/react-front-app/src/components/page/Banner.js
+++ b/react-front-app/src/components/page/Banner.js
@@ -2,6 +2,8 @@ import Carousel from 'react-bootstrap/Carousel';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { LazyLoadImage } from 'react-lazy-load-image-component';
+import 'react-lazy-load-image-component/src/effects/blur.css';
 
 const IMG_PER_BANNER = 3; //배너 하나당 포함되는 사진 수
 
@@ -45,6 +47,7 @@ const Banner = () => {
                 url: `http://192.168.0.115:8080/stwist-api/category/${cat.code}?size=${IMG_PER_BANNER}&srt=I`,
                 responseType: 'json',
               }).then((res) => {
+                console.log(res.data);
                 const category = res.data.category;
                 const banner = {
                   name: category.name,
@@ -70,11 +73,10 @@ const Banner = () => {
         <Carousel.Item key={i}>
           <div className="d-flex justify-content-center w-100">
             {banner.image.map((img, i) => (
-              <img
-                className="lazyload"
-                data-src={img.high} //최종 high resolution img
-                src={img.low} //lazyload의 low resolution img
+              <LazyLoadImage
+                src={img.high} //lazyload의 low resolution img
                 key={i}
+                effect="blur"
                 alt={i + '번 이미지'}
                 width="300"
                 height="300"

--- a/react-front-app/src/components/page/Banner.js
+++ b/react-front-app/src/components/page/Banner.js
@@ -1,0 +1,93 @@
+import Carousel from 'react-bootstrap/Carousel';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+import { useState, useEffect } from 'react';
+
+const IMG_PER_BANNER = 3; //배너 하나당 포함되는 사진 수
+
+/**
+ * 해당 카테고리와 그 하위의 리프 카테고리를 리프 리스트에 추가해준다.
+ * 인자의 카테고리가 리프 카테고리면 리스트에 넣고 아니면 자식 리스트에 대해 재귀 호출
+ * @param {*} category 검사 대상 카테고리
+ * @param {*} leafList 리프 카테고리들이 저장될 리스트
+ */
+const findLeafCat = (category, leafList) => {
+  if (category.child) {
+    for (let sub of category.child) {
+      findLeafCat(sub, leafList);
+    }
+  } else {
+    leafList.push(category);
+  }
+};
+
+const Banner = () => {
+  const [banners, setBanners] = new useState([]);
+
+  useEffect(() => {
+    axios({
+      method: 'get',
+      url: 'http://192.168.0.115:8080/stwist-api/category',
+      responseType: 'json',
+    })
+      .then((res) => {
+        let banners = [];
+        let catList = [];
+        for (let sub of res.data.categories) {
+          findLeafCat(sub, catList);
+        }
+        console.log(catList);
+        Promise.all(
+          catList.map(
+            (cat) =>
+              axios({
+                method: 'get',
+                url: `http://192.168.0.115:8080/stwist-api/category/${cat.code}?size=${IMG_PER_BANNER}&srt=I`,
+                responseType: 'json',
+              }).then((res) => {
+                const category = res.data.category;
+                const banner = {
+                  name: category.name,
+                  code: category.code,
+                  image: res.data.products.items.map((item) => item.image),
+                };
+                if (banner.image.length >= IMG_PER_BANNER) {
+                  banners.push(banner);
+                }
+              }), //items가 없는 카테고리도 있음, BANNER를 꽉 체울 크기인 것들만 집어넣음.
+          ),
+        ).then(() => {
+          console.log(banners);
+          setBanners(banners);
+        });
+      })
+      .catch((e) => console.log(e));
+  }, [setBanners]);
+
+  return (
+    <Carousel>
+      {banners.map((banner, i) => (
+        <Carousel.Item key={i}>
+          <div className="d-flex justify-content-center w-100">
+            {banner.image.map((img, i) => (
+              <img
+                className="lazyload"
+                data-src={img.high} //최종 high resolution img
+                src={img.low} //lazyload의 low resolution img
+                key={i}
+                alt={i + '번 이미지'}
+                width="300"
+                height="300"
+              />
+            ))}
+          </div>
+          <Carousel.Caption>
+            <h3>{banner.name}</h3>
+            <Link to={'list?code=' + banner.code}>상품 보러가기</Link>
+          </Carousel.Caption>
+        </Carousel.Item>
+      ))}
+    </Carousel>
+  );
+};
+export default Banner;

--- a/react-front-app/src/pages/HomePage.js
+++ b/react-front-app/src/pages/HomePage.js
@@ -1,90 +1,14 @@
 import CommonHeader from '../components/common/CommonHeader';
-import Carousel from 'react-bootstrap/Carousel';
 import Container from 'react-bootstrap/Container';
-import axios from 'axios';
-import { useState, useEffect } from 'react';
-import { Link } from "react-router-dom";
-
-const IMG_PER_BANNER = 3; //배너 하나당 포함되는 사진 수
-
-const findLeafCat = (category, leafList) => {
-  if (category.child) {
-    for (let sub of category.child) {
-      findLeafCat(sub, leafList);
-    }
-  } else {
-    leafList.push(category);
-  }
-};
+import Banner from '../components/page/Banner';
 
 const Home = () => {
-  const [banners, setBanners] = new useState([]);
-
-  useEffect(() => {
-    axios({
-      method: 'get',
-      url: 'http://192.168.0.115:8080/stwist-api/category',
-      responseType: 'json',
-    })
-      .then((res) => {
-        let banners = [];
-        let catList = [];
-        for (let sub of res.data.categories) {
-          findLeafCat(sub, catList);
-        }
-        console.log(catList);
-        Promise.all(
-          catList.map(
-            (cat) =>
-              axios({
-                method: 'get',
-                url: `http://192.168.0.115:8080/stwist-api/category/${cat.code}?size=${IMG_PER_BANNER}&srt=I`,
-                responseType: 'json',
-              }).then((res) => {
-                const category = res.data.category;
-                const banner = {
-                  name: category.name,
-                  code: category.code,
-                  image: res.data.products.items.map((item) => item.image),
-                };
-                if (banner.image.length >= IMG_PER_BANNER) {
-                  banners.push(banner);
-                }
-              }), //items가 없는 카테고리도 있음, BANNER를 꽉 체울 크기인 것들만 집어넣음.
-          ),
-        ).then(() => {
-          console.log(banners);
-          setBanners(banners);
-        });
-      })
-      .catch((e) => console.log(e));
-  }, [setBanners]);
-
   return (
     <>
       <CommonHeader />
-      <Container fluid="lg" />
-      <Carousel>
-        {banners.map((banner, i) => (
-          <Carousel.Item key={i}>
-            <div className="d-flex justify-content-center w-100">
-              {banner.image.map((img, i) => (
-                <img
-                  src={img}
-                  key={i}
-                  alt={i + '번 이미지'}
-                  width="300"
-                  height="300"
-                />
-              ))}
-            </div>
-            <Carousel.Caption>
-              <h3>{banner.name}</h3>
-              <Link to={'list?code='+banner.code}>상품 보러가기</Link>
-            </Carousel.Caption>
-          </Carousel.Item>
-        ))}
-      </Carousel>
+      <Banner />
+      <Container fluid="lg">
+      </Container>
     </>
   );
 };

--- a/react-front-app/src/pages/HomePage.js
+++ b/react-front-app/src/pages/HomePage.js
@@ -3,21 +3,22 @@ import Carousel from 'react-bootstrap/Carousel';
 import Container from 'react-bootstrap/Container';
 import axios from 'axios';
 import { useState, useEffect } from 'react';
+import { Link } from "react-router-dom";
 
 const IMG_PER_BANNER = 3; //배너 하나당 포함되는 사진 수
 
-const findLeafCat = (category, leafList)=>{
-  if(category.child){
-    for(let sub of category.child){
+const findLeafCat = (category, leafList) => {
+  if (category.child) {
+    for (let sub of category.child) {
       findLeafCat(sub, leafList);
     }
-  }else{
+  } else {
     leafList.push(category);
   }
-}
+};
 
 const Home = () => {
-  const [bannerImgs, setBannerImgs] = new useState([]);
+  const [banners, setBanners] = new useState([]);
 
   useEffect(() => {
     axios({
@@ -28,57 +29,58 @@ const Home = () => {
       .then((res) => {
         let banners = [];
         let catList = [];
-        for(let sub of res.data.categories){
+        for (let sub of res.data.categories) {
           findLeafCat(sub, catList);
         }
         console.log(catList);
         Promise.all(
-          catList.map((cat) =>
-            axios({
-              method: 'get',
-              url: `http://192.168.0.115:8080/stwist-api/category/${cat.code}?size=${IMG_PER_BANNER}&srt=I`,
-              responseType: 'json',
-            }).then((res) => {
-              const category = res.data.category;
-              const banner = {
-                name : category.name,
-                code : category.code,
-                image : res.data.products.items.map((item) => item.image)
-              };
-              if(banner.image.length>=IMG_PER_BANNER){
-                banners.push(banner);
-              }
-            }),//items가 없는 카테고리도 있음, BANNER를 꽉 체울 크기인 것들만 집어넣음.
+          catList.map(
+            (cat) =>
+              axios({
+                method: 'get',
+                url: `http://192.168.0.115:8080/stwist-api/category/${cat.code}?size=${IMG_PER_BANNER}&srt=I`,
+                responseType: 'json',
+              }).then((res) => {
+                const category = res.data.category;
+                const banner = {
+                  name: category.name,
+                  code: category.code,
+                  image: res.data.products.items.map((item) => item.image),
+                };
+                if (banner.image.length >= IMG_PER_BANNER) {
+                  banners.push(banner);
+                }
+              }), //items가 없는 카테고리도 있음, BANNER를 꽉 체울 크기인 것들만 집어넣음.
           ),
         ).then(() => {
           console.log(banners);
-          setBannerImgs(banners);
+          setBanners(banners);
         });
       })
       .catch((e) => console.log(e));
-  }, [setBannerImgs]);
+  }, [setBanners]);
 
   return (
     <>
       <CommonHeader />
       <Container fluid="lg" />
       <Carousel>
-        {bannerImgs.map((imgs, i) => (
+        {banners.map((banner, i) => (
           <Carousel.Item key={i}>
             <div className="d-flex justify-content-center w-100">
-              {imgs.image.map((img, i) => (
+              {banner.image.map((img, i) => (
                 <img
                   src={img}
                   key={i}
-                  alt="First slide"
+                  alt={i + '번 이미지'}
                   width="300"
                   height="300"
                 />
               ))}
             </div>
             <Carousel.Caption>
-              <h3>First slide label</h3>
-              <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+              <h3>{banner.name}</h3>
+              <Link to={'list?code='+banner.code}>상품 보러가기</Link>
             </Carousel.Caption>
           </Carousel.Item>
         ))}

--- a/react-front-app/src/pages/HomePage.js
+++ b/react-front-app/src/pages/HomePage.js
@@ -17,7 +17,7 @@ const Home = () => {
     })
       .then((res) => {
         let images = [];
-        let catList = res.data;
+        let catList = res.data.categories;
         Promise.all(
           catList.map((cat) =>
             axios({
@@ -26,7 +26,7 @@ const Home = () => {
               responseType: 'json',
             }).then((res) => {
               const items = res.data.products.items;
-              items&&images.push(items.map((item) => item.image));
+              items&&items.map((item) => images.push(item.image));
             }),//items가 없는 카테고리도 있음, BANNER를 꽉 체울 크기인 것들만 집어넣음.
           ),
         ).then(() => {

--- a/react-front-app/yarn.lock
+++ b/react-front-app/yarn.lock
@@ -6068,11 +6068,6 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "^0.3.20"
 
-lazyload@^2.0.0-rc.2:
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/lazyload/-/lazyload-2.0.0-rc.2.tgz#c774eb7966f334c9bed2f27580fc333a770eb256"
-  integrity sha512-v3OKwYrKHX09eAyeAmkpvVCF5qWZo8rxERT9AVOUFaRwlTIuCyMYVBfHYSra1uyBdKDEHnUkvpZTLgNWI9Y7lA==
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -6164,6 +6159,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -7572,6 +7572,14 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-lazy-load-image-component@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/react-lazy-load-image-component/-/react-lazy-load-image-component-1.5.6.tgz#a4b84257be21b1825680b4e158d167c08aeda5ff"
+  integrity sha512-M0jeJtOlTHgThOfgYM9krSqYbR6ShxROy/KVankwbw9/amPKG1t5GSGN1sei6Cyu8+QJVuyAUvQ+LFtCVTTlKw==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"

--- a/react-front-app/yarn.lock
+++ b/react-front-app/yarn.lock
@@ -6068,6 +6068,11 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "^0.3.20"
 
+lazyload@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/lazyload/-/lazyload-2.0.0-rc.2.tgz#c774eb7966f334c9bed2f27580fc333a770eb256"
+  integrity sha512-v3OKwYrKHX09eAyeAmkpvVCF5qWZo8rxERT9AVOUFaRwlTIuCyMYVBfHYSra1uyBdKDEHnUkvpZTLgNWI9Y7lA==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -39,7 +39,7 @@ module.exports = async (query) => {
       products: {
         count: result.CategoryResponse.Products.TotalCount._text,
         items:
-          result.CategoryResponse.Products.Product &&
+          result.CategoryResponse.Products.Product ?
           (result.CategoryResponse.Products.Product.map
             ? result.CategoryResponse.Products.Product.map((prod) => ({
                 code: prod.ProductCode._text,
@@ -47,7 +47,7 @@ module.exports = async (query) => {
                 price: prod.ProductPrice._text,
                 image: prod.ProductImage300._cdata,
               }))
-            : {
+            : [{
                 code: result.CategoryResponse.Products.Product.ProductCode
                   ._text,
                 name: result.CategoryResponse.Products.Product.ProductName
@@ -57,7 +57,7 @@ module.exports = async (query) => {
                 image:
                   result.CategoryResponse.Products.Product.ProductImage300
                     ._cdata,
-              }),
+              }]):[],
       },
       category: {
         name: result.CategoryResponse.Category.CategoryName._cdata,

--- a/services/eleven/categoryInfo.js
+++ b/services/eleven/categoryInfo.js
@@ -38,26 +38,34 @@ module.exports = async (query) => {
     .then((result) => ({
       products: {
         count: result.CategoryResponse.Products.TotalCount._text,
-        items:
-          result.CategoryResponse.Products.Product ?
-          (result.CategoryResponse.Products.Product.map
+        items: result.CategoryResponse.Products.Product
+          ? result.CategoryResponse.Products.Product.map
             ? result.CategoryResponse.Products.Product.map((prod) => ({
                 code: prod.ProductCode._text,
                 name: prod.ProductName._cdata,
                 price: prod.ProductPrice._text,
-                image: prod.ProductImage300._cdata,
+                image: {
+                  low: prod.ProductImage100._cdata,
+                  high: prod.ProductImage300._cdata,
+                },
               }))
-            : [{
-                code: result.CategoryResponse.Products.Product.ProductCode
-                  ._text,
-                name: result.CategoryResponse.Products.Product.ProductName
-                  ._cdata,
-                price:
-                  result.CategoryResponse.Products.Product.ProductPrice._text,
-                image:
-                  result.CategoryResponse.Products.Product.ProductImage300
+            : [
+                {
+                  code: result.CategoryResponse.Products.Product.ProductCode
+                    ._text,
+                  name: result.CategoryResponse.Products.Product.ProductName
                     ._cdata,
-              }]):[],
+                  price:
+                    result.CategoryResponse.Products.Product.ProductPrice._text,
+                  image: {
+                    low: result.CategoryResponse.Products.Product
+                      .ProductImage100._cdata,
+                    high: result.CategoryResponse.Products.Product
+                      .ProductImage300._cdata,
+                  },
+                },
+              ]
+          : [],
       },
       category: {
         name: result.CategoryResponse.Category.CategoryName._cdata,

--- a/services/getCatSet.js
+++ b/services/getCatSet.js
@@ -83,8 +83,8 @@ const classifyTop = (category, top, pants) => {
     for (let subCat of category.child) {
       classifyTop(subCat, tempTop, tempPants);
     }
-    top.push({name:category.name,child:tempTop});
-    pants.push({name:category.name,child:tempPants});
+    top.push({ name: category.name, child: tempTop });
+    pants.push({ name: category.name, child: tempPants });
   } else {
     if (category.top) {
       top.push(category);
@@ -100,9 +100,9 @@ module.exports = () => {
   for (let category of categories) {
     classifyTop(category, top, pants);
   }
-  return [
-    ...categories,
-    { name: 'top', child: top },
-    { name: 'pants', child: pants },
-  ];
+  return {
+    categories: categories,
+    top: top,
+    pants: pants,
+  };
 };


### PR DESCRIPTION
### Category API 패치

- 응답 구조 변경 -> 단순배열에서, 구조화된 객체로, top, pants 카테고리를 다른 카테고리들(categories)과 분리, categories는 배열로 원본이 되는 카테고리들을 가지고 있음, top과 pants는 카테고리들을 상위, 하위로 분류해서 다시 조합한 객체임.
- category API가 반환하는 JSON 구조를 일관성 있게 바꿈, 기존 구조는 Open API 응답에 요소의 하의 요소가 여러개면 배열, 한개면 단일오브젝트, 없으면 undefined 였던 문제가 있음, 새버전에서 이걸 전부 배열로 바꿔 클라이언트로 응답해줌. 
- blur up 기법에 사용하거나 썸네일로 사용할 수도 있으니까

### 배너 패치

- HomePage컴포넌트에서 배너 컴포넌트 추출
- 배너 이미지에 Lazy Load 적용, 이미지 뜨기전에 블러 효과 주고, 전반적인 로드 속도 개선.

### .gitignore에 lock 파일들 추가

- yarn.lock
- package-lock.json

