### PR TITLE
카테고리에 대한 상품목록 상태 인덱싱 방법 바꿈

### DIFF
--- a/react-front-app/src/hooks/useGetProductListByI.js
+++ b/react-front-app/src/hooks/useGetProductListByI.js
@@ -11,6 +11,7 @@ export default function useGetProductListByI({code, pg}) {
   const dispatch = useAppDispatch();
   const status = useSelector((state) => selectStatus(state,{code,pg}));
   const productListByI = useSelector((state) => selectData(state,{code,pg}));
+  console.log(productListByI);
   useEffect(() => {
     if (status === undefined) {
       dispatch(fetchProductListByI({code, pg}));

--- a/react-front-app/src/services/productListByISlice.js
+++ b/react-front-app/src/services/productListByISlice.js
@@ -2,8 +2,6 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import axios from 'axios';
 import server from '../server.json';
 
-const initialState = { data: {}, status : {} };
-
 /**
  * srt=I로 요청한 상품 리스트가 저장.
  */
@@ -23,27 +21,26 @@ export const fetchProductListByI = createAsyncThunk(
   },
 );
 
+
+const getStateIndex = ({code, pg})=> code+'/'+pg;
+
 export const productListByISlice = createSlice({
   name: 'productListByI',
-  initialState,
+  initialState : { data: {}, status : {} },
   reducers: [],
   extraReducers: (builder) => {
     builder.addCase(fetchProductListByI.pending, (state, action) => {
-      if(!state.status[action.meta.arg.code])state.status[action.meta.arg.code]={};
-      state.status[action.meta.arg.code][action.meta.arg.pg] = 'pending';
+      state.status[getStateIndex(action.meta.arg)] = 'pending';
     });
     builder.addCase(fetchProductListByI.fulfilled, (state, action) => {
-      if(!state.status[action.meta.arg.code])state.status[action.meta.arg.code]={};
-      state.status[action.meta.arg.code][action.meta.arg.pg] = 'fulfilled';
-      if(!state.data[action.meta.arg.code])state.data[action.meta.arg.code]={};
-      state.data[action.meta.arg.code][action.meta.arg.pg] = action.payload;
+      state.status[getStateIndex(action.meta.arg)] = 'fulfilled';
+      state.data[getStateIndex(action.meta.arg)] = action.payload;
     });
     builder.addCase(fetchProductListByI.rejected, (state, action) => {
-      if(!state.status[action.meta.arg.code])state.status[action.meta.arg.code]={};
-      state.status[action.meta.arg.code][action.meta.arg.pg] = 'rejected';
+      state.status[getStateIndex(action.meta.arg)] = 'rejected';
     });
   },
 });
 
-export const selectStatus = (state, {code, pg}) => state.productListByI.status[code]&&state.productListByI.status[code][pg];
-export const selectData = (state, {code, pg}) => state.productListByI.data[code]&&state.productListByI.data[code][pg];
+export const selectStatus = (state, {code, pg}) => state.productListByI.status[getStateIndex({code,pg})];
+export const selectData = (state, {code, pg}) => state.productListByI.data[getStateIndex({code,pg})];


### PR DESCRIPTION
- productListByISlice에 입력 파라미터로 상태를 인덱싱하는 방법을 1차원 배열로 바꿈. 하위 차원 배열이 상위 차원 배열에 접근할 때 생길 수 있는  undefined 예외를 처리하는 복잡한 로직이 필요 없어짐.
- slash 구분자로 각 파라미터를 구분해서 하나의 문자열로 생성.