### PR TITLE
payloadCreator의 arg이름 arg로 바꿈

### DIFF
--- a/react-front-app/src/services/categoryListSlice.js
+++ b/react-front-app/src/services/categoryListSlice.js
@@ -4,7 +4,7 @@ import server from '../server.json';
 
 export const fetchCategoryList = createAsyncThunk(
   'categoryList/fetch',
-  async (name, { rejectWithValue }) => {
+  async (arg, { rejectWithValue }) => {
     const response = await axios({
       method: 'get',
       url: `http://${server.host}/stwist-api/category`,


### PR DESCRIPTION
- 아무것도 안받기 때문에 원래 이름 쓰는게 좋아보임